### PR TITLE
URL Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Change Log
-All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](https://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,3 @@
 # Introduction to jepsen.mnevis
 
-TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)
+TODO: write [great documentation](https://jacobian.org/writing/what-to-write/)

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject jepsen.mnevis "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
-  :url "http://example.com/FIXME"
+  :url "https://example.com/FIXME"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url "https://www.eclipse.org/legal/epl-v10.html"}
   :main jepsen.mnevis
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [jepsen "0.1.8"]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://example.com/FIXME (404) with 1 occurrences migrated to:  
  https://example.com/FIXME ([https](https://example.com/FIXME) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://keepachangelog.com/ with 1 occurrences migrated to:  
  https://keepachangelog.com/ ([https](https://keepachangelog.com/) result 200).
* http://www.eclipse.org/legal/epl-v10.html with 1 occurrences migrated to:  
  https://www.eclipse.org/legal/epl-v10.html ([https](https://www.eclipse.org/legal/epl-v10.html) result 200).
* http://jacobian.org/writing/what-to-write/ with 1 occurrences migrated to:  
  https://jacobian.org/writing/what-to-write/ ([https](https://jacobian.org/writing/what-to-write/) result 301).